### PR TITLE
feat(console): add # key to open game console (for macos)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,7 +64,7 @@ Contains scenes like levels and menus.
 ### Scenes/Console
 
 The `GameConsole` is a UI for developers which allows to enter commands for debugging.
-By default, on an AZERTY it opens when typing the "²" key.
+By default, on an AZERTY it opens when typing the "²" key or "#".
 
 To add it to a scene, add the `GameConsole` to it, and add `Command` children nodes.
 Every `Command` nodes have to be configured to **target** an existing node of the scene,

--- a/project.godot
+++ b/project.godot
@@ -75,6 +75,7 @@ move_left={
 show_game_console={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":96,"key_label":0,"unicode":178,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":true,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":167,"key_label":0,"unicode":35,"location":0,"echo":false,"script":null)
 ]
 }
 exit={


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The keybinding "²" was not available on macOS. So we need to add a new key to open debug menu like "#"

## Motivation and Context
Open the debug menu on my Mac 

## How has this been tested?
Launch the template and try ;)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.