### PR TITLE
feat(multiplayer): synchronization navigation menu

### DIFF
--- a/objects/actors/player/Player.tscn
+++ b/objects/actors/player/Player.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="PackedScene" uid="uid://du0c1yciw8ul6" path="res://objects/actors/Actor.tscn" id="1_wrkhm"]
 [ext_resource type="Script" path="res://objects/actors/player/Player.gd" id="2_bhjnv"]
+[ext_resource type="Resource" uid="uid://r3i80a6v2w0y" path="res://resources/weapons/gun/Gun.tres" id="3_irbyu"]
 [ext_resource type="Texture2D" uid="uid://cnwmhohk8wm23" path="res://objects/actors/player/Player.png" id="3_pkisr"]
 [ext_resource type="PackedScene" uid="uid://cxlkjx4h6gv5h" path="res://components/collector/Collector.tscn" id="5_q1uwo"]
 
@@ -225,7 +226,7 @@ _data = {
 collision_mask = 7
 script = ExtResource("2_bhjnv")
 chestModifierSpeed = 0.7
-weapon = null
+weapon = ExtResource("3_irbyu")
 
 [node name="MultiplayerSynchronizer" type="MultiplayerSynchronizer" parent="." index="0"]
 replication_config = SubResource("SceneReplicationConfig_p4sxr")

--- a/scenes/map/Map.gd
+++ b/scenes/map/Map.gd
@@ -6,7 +6,7 @@ extends Node2D
 func _on_island_clicked(island_marker: IslandMarker):
 	if !multiplayer.is_server(): return
 	prints("Island", island_marker.id, "clicked")
-	rpc("_navigate_to_island", island_marker.position)
+	_navigate_to_island.rpc(island_marker.position)
 
 @rpc("call_local")	
 func _navigate_to_island(target_position: Vector2) -> void:

--- a/scenes/map/Map.gd
+++ b/scenes/map/Map.gd
@@ -1,15 +1,22 @@
 extends Node2D
 
 @onready var ship: Sprite2D = %ShipSprite
-
 @export var ship_speed: int = 70
 
 func _on_island_clicked(island_marker: IslandMarker):
+	if !multiplayer.is_server(): return
 	prints("Island", island_marker.id, "clicked")
+	rpc("_navigate_to_island", island_marker.position)
+
+@rpc("call_local")	
+func _navigate_to_island(target_position: Vector2) -> void:
 	var tween: Tween = get_tree().create_tween().set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_IN_OUT)
-	tween.tween_property(ship, "position", island_marker.position, 2)
+	tween.tween_property(ship, "position", target_position, 2)
 	tween.tween_callback(_on_island_entered)
 
-
 func _on_island_entered():
+	load_weapon_screen.rpc()
+	
+@rpc("call_local")
+func load_weapon_screen() -> void:
 	SceneTransition.change_scene("res://scenes/menus/weapon/WeaponChoice.tscn")

--- a/scenes/map/Map.gd
+++ b/scenes/map/Map.gd
@@ -15,8 +15,8 @@ func _navigate_to_island(target_position: Vector2) -> void:
 	tween.tween_callback(_on_island_entered)
 
 func _on_island_entered():
-	load_weapon_screen.rpc()
+	_load_weapon_screen.rpc()
 	
 @rpc("call_local")
-func load_weapon_screen() -> void:
+func _load_weapon_screen() -> void:
 	SceneTransition.change_scene("res://scenes/menus/weapon/WeaponChoice.tscn")

--- a/scenes/menus/lobby/Lobby.gd
+++ b/scenes/menus/lobby/Lobby.gd
@@ -73,10 +73,10 @@ func _check_address(address: String):
 
 func _on_play_pressed() -> void:
 	waiting_room.hide()
-	load_map.rpc()
+	_load_map.rpc()
 
 @rpc("call_local")
-func load_map() -> void:
+func _load_map() -> void:
 	SceneTransition.change_scene("res://scenes/map/Map.tscn")
 
 func _on_connection_success() -> void:

--- a/scenes/menus/lobby/Lobby.gd
+++ b/scenes/menus/lobby/Lobby.gd
@@ -33,7 +33,6 @@ func _ready() -> void:
 	else:
 		player_name_input.text = "Pirate"
 
-
 func _on_host_pressed() -> void:
 	var player_name: String = player_name_input.text.strip_edges()
 	if !_check_player_name(player_name): return
@@ -44,7 +43,6 @@ func _on_host_pressed() -> void:
 
 	MultiplayerManager.host_game(player_name)
 	refresh_waiting_room()
-
 
 func _on_join_pressed() -> void:
 	var player_name: String = player_name_input.text.strip_edges()
@@ -59,14 +57,12 @@ func _on_join_pressed() -> void:
 
 	MultiplayerManager.join_game(host_address, player_name)
 
-
 func _check_player_name(name: String):
 	if name.is_empty():
 		error_label.text = "Invalid name!"
 		return false
 	else:
 		return true
-
 
 func _check_address(address: String):
 	if address.is_empty():
@@ -75,29 +71,28 @@ func _check_address(address: String):
 	else:
 		return true
 
-
 func _on_play_pressed() -> void:
-	SceneTransition.change_scene("res://scenes/map/Map.tscn")
 	waiting_room.hide()
+	load_map.rpc()
 
+@rpc("call_local")
+func load_map() -> void:
+	SceneTransition.change_scene("res://scenes/map/Map.tscn")
 
 func _on_connection_success() -> void:
 	connect.hide()
 	waiting_room.show()
-
 
 func _on_connection_failed() -> void:
 	host_button.disabled = false
 	join_button.disabled = false
 	error_label.set_text("Connection failed.")
 
-
 func _on_game_error(errtxt: String) -> void:
 	alert_dialog.dialog_text = errtxt
 	alert_dialog.popup_centered()
 	host_button.disabled = false
 	join_button.disabled = false
-
 
 func refresh_waiting_room() -> void:
 	var players := MultiplayerManager.get_player_name_list()

--- a/scenes/menus/lobby/Lobby.tscn
+++ b/scenes/menus/lobby/Lobby.tscn
@@ -1,11 +1,6 @@
-[gd_scene load_steps=4 format=3 uid="uid://dichwckdkqj4o"]
+[gd_scene load_steps=3 format=3 uid="uid://dichwckdkqj4o"]
 
 [ext_resource type="Script" path="res://scenes/menus/lobby/Lobby.gd" id="1_y2wkh"]
-
-[sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_rtipl"]
-properties/0/path = NodePath(".:visible")
-properties/0/spawn = true
-properties/0/replication_mode = 2
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_bgvch"]
 
@@ -17,10 +12,6 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_y2wkh")
-
-[node name="MultiplayerSpawner" type="MultiplayerSpawner" parent="."]
-_spawnable_scenes = PackedStringArray("res://scenes/levels/debug/DebugLevel.tscn")
-spawn_path = NodePath("..")
 
 [node name="WaitingRoom" type="Panel" parent="."]
 visible = false
@@ -35,9 +26,6 @@ offset_right = 290.0
 offset_bottom = -1.0
 grow_horizontal = 2
 grow_vertical = 2
-
-[node name="MultiplayerSynchronizer" type="MultiplayerSynchronizer" parent="WaitingRoom"]
-replication_config = SubResource("SceneReplicationConfig_rtipl")
 
 [node name="Title" type="Label" parent="WaitingRoom"]
 layout_mode = 2

--- a/scenes/menus/weapon/WeaponChoice.gd
+++ b/scenes/menus/weapon/WeaponChoice.gd
@@ -7,7 +7,6 @@ extends Control
 var weapon_choice_button: PackedScene = load('res://scenes/menus/weapon/button/WeaponChoiceButton.tscn')
 
 func _ready() -> void:
-	
 	for weapon in weapons:
 		var button = weapon_choice_button.instantiate()
 		button.init(weapon)

--- a/scenes/menus/weapon/WeaponChoice.gd
+++ b/scenes/menus/weapon/WeaponChoice.gd
@@ -1,6 +1,5 @@
 extends Control
 
-
 ## TODO: this could be given dynamically when we have a boat scene
 @export var weapons: Array[Weapon] = []; 
 

--- a/scenes/menus/weapon/WeaponChoice.gd
+++ b/scenes/menus/weapon/WeaponChoice.gd
@@ -1,5 +1,6 @@
 extends Control
 
+
 ## TODO: this could be given dynamically when we have a boat scene
 @export var weapons: Array[Weapon] = []; 
 
@@ -7,8 +8,18 @@ extends Control
 var weapon_choice_button: PackedScene = load('res://scenes/menus/weapon/button/WeaponChoiceButton.tscn')
 
 func _ready() -> void:
+	
 	for weapon in weapons:
 		var button = weapon_choice_button.instantiate()
 		button.init(weapon)
 		
 		weapons_container.add_child(button)
+		button.player_choose_weapon.connect(_players_is_ready)
+
+func _players_is_ready():
+	if !multiplayer.is_server(): return
+	_load_island.rpc()
+
+@rpc("call_local")
+func _load_island() -> void:
+	SceneTransition.change_scene("res://scenes/levels/islands/island.tscn")

--- a/scenes/menus/weapon/WeaponChoice.gd
+++ b/scenes/menus/weapon/WeaponChoice.gd
@@ -20,6 +20,6 @@ func _players_is_ready():
 	if !multiplayer.is_server(): return
 	_load_island.rpc()
 
-@rpc("call_local")
+@rpc("call_local", "reliable")
 func _load_island() -> void:
 	SceneTransition.change_scene("res://scenes/levels/islands/island.tscn")

--- a/scenes/menus/weapon/button/WeaponChoiceButton.gd
+++ b/scenes/menus/weapon/button/WeaponChoiceButton.gd
@@ -1,5 +1,7 @@
 extends Control
 
+signal player_choose_weapon()
+
 @onready var weapon_icon: TextureRect = %WeaponIcon
 @onready var weapon_name: Label = %WeaponName
 @onready var damage_value_label: Label = %DamageValue
@@ -23,4 +25,4 @@ func _ready() -> void:
 func _on_button_pressed() -> void:
 	StoreManager.player_weapon = _weapon
 	print("Weapon selected is ", _weapon.name, " : ", _weapon)
-	SceneTransition.change_scene("res://scenes/levels/islands/island.tscn")
+	player_choose_weapon.emit()

--- a/services/multiplayer/MultiplayerManager.gd
+++ b/services/multiplayer/MultiplayerManager.gd
@@ -79,7 +79,7 @@ func join_game(ip: String, new_player_name: String) -> void:
 	var result = peer.create_client(ip, DEFAULT_PORT)
 	if result == OK:
 		multiplayer.set_multiplayer_peer(peer)
-		print("Server joined successfully on ip %d" % ip)
+		print("Server joined successfully on ip %s" % ip)
 	else:
 		game_error.emit("Failed to join server. Error code: %d" % result)
 #endregion Lobby management functions.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Synchronize navigation across lobby, map, and weapon menus.

Informations
- All players are assigned a default weapon (a gun)
- This feature doesn’t include the mechanic to check if all clients have selected a weapon before enabling the 'Play Game' button.

Note: If you're new to RPC calls with Godot, you may want to read [the documentation](https://docs.godotengine.org/en/stable/classes/class_@gdscript.html#class-gdscript-annotation-rpc).

## Motivation and Context
The first step before spawning players on the island to fight the mob!

## How has this been tested?

1.Run two Godot instances locally on the same machine to test multiplayer gameplay.

2.Run the game on two separate computers over different networks to test online multiplayer connectivity.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.