### PR TITLE
feat: save current island and boat position on map

### DIFF
--- a/objects/boat/Boat.gd
+++ b/objects/boat/Boat.gd
@@ -7,4 +7,8 @@ var can_enter = false
 
 func _on_enter():
 	if can_enter:
-		on_leave_level.emit()
+		_navigate_to_map.rpc()
+
+@rpc("call_local")
+func _navigate_to_map():
+	on_leave_level.emit()

--- a/scenes/map/IslandMarker.gd
+++ b/scenes/map/IslandMarker.gd
@@ -3,12 +3,20 @@ extends Node2D
 
 signal click(island_marker: IslandMarker)
 
-@export var id: String
+@export var id: int
 @export var enabled: bool = true:
 	set(value): 
 		enabled = value
 		%Clickable.disabled = !value
 
+func _ready():
+	if !multiplayer.is_server():
+		%Clickable.queue_free()
+
 func _on_click():
 	if (enabled):
 		click.emit(self)
+		
+func disable():
+	enabled = false
+	modulate = Color.DIM_GRAY

--- a/scenes/map/Map.gd
+++ b/scenes/map/Map.gd
@@ -3,9 +3,19 @@ extends Node2D
 @onready var ship: Sprite2D = %ShipSprite
 @export var ship_speed: int = 70
 
+func _ready():
+	var current_island = StoreManager.current_island;
+	var children = get_children();
+	for child in children:
+		if not child is IslandMarker: continue
+		if child.id <= current_island:
+			child.disable()
+		if child.id == current_island:
+			ship.global_position = child.global_position
+
 func _on_island_clicked(island_marker: IslandMarker):
-	if !multiplayer.is_server(): return
 	prints("Island", island_marker.id, "clicked")
+	_update_current_island.rpc(island_marker.id)
 	_navigate_to_island.rpc(island_marker.position)
 
 @rpc("call_local")	
@@ -20,3 +30,7 @@ func _on_island_entered():
 @rpc("call_local")
 func _load_weapon_screen() -> void:
 	SceneTransition.change_scene("res://scenes/menus/weapon/WeaponChoice.tscn")
+
+@rpc("call_local")
+func _update_current_island(id: int) -> void:
+	StoreManager.current_island = id

--- a/scenes/map/Map.tscn
+++ b/scenes/map/Map.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://dscw6cfkblva7"]
+[gd_scene load_steps=6 format=3 uid="uid://dscw6cfkblva7"]
 
 [ext_resource type="Script" path="res://scenes/map/Map.gd" id="1_bve3w"]
 [ext_resource type="PackedScene" uid="uid://b2cw2h2f6hqtg" path="res://scenes/map/IslandMarker.tscn" id="2_k1m28"]
@@ -11,8 +11,6 @@ colors = PackedColorArray(0.0666667, 0.360784, 1, 1, 0.0666667, 0.360784, 1, 1, 
 [sub_resource type="GradientTexture2D" id="GradientTexture2D_plyeg"]
 gradient = SubResource("Gradient_lqywo")
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_6tl2x"]
-
 [node name="Map" type="Node2D"]
 script = ExtResource("1_bve3w")
 
@@ -24,29 +22,22 @@ texture = SubResource("GradientTexture2D_plyeg")
 [node name="IslandMarker0" parent="." instance=ExtResource("2_k1m28")]
 unique_name_in_owner = true
 position = Vector2(250.084, 224.981)
-id = "island-0"
 
 [node name="IslandMarker1" parent="." instance=ExtResource("2_k1m28")]
 unique_name_in_owner = true
 position = Vector2(407.369, 151.825)
-id = "island-1"
+id = 1
 
 [node name="IslandMarker2" parent="." instance=ExtResource("2_k1m28")]
 unique_name_in_owner = true
 position = Vector2(320, 60)
-id = "Final"
+id = 2
 
 [node name="ShipSprite" type="Sprite2D" parent="."]
 unique_name_in_owner = true
 position = Vector2(320, 300)
 scale = Vector2(-1, 1)
 texture = ExtResource("3_tsrsh")
-
-[node name="Area2D" type="Area2D" parent="ShipSprite"]
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="ShipSprite/Area2D"]
-shape = SubResource("RectangleShape2D_6tl2x")
-debug_color = Color(1, 0, 0, 0.419608)
 
 [connection signal="click" from="IslandMarker0" to="." method="_on_island_clicked"]
 [connection signal="click" from="IslandMarker1" to="." method="_on_island_clicked"]

--- a/services/managers/store/StoreManager.gd
+++ b/services/managers/store/StoreManager.gd
@@ -1,3 +1,4 @@
 extends Node2D
 
 var player_weapon: Weapon
+var current_island: int = -1


### PR DESCRIPTION
Save current island and boat position on map

## Description
- Add current island variable in StoreManager
- Update boat position on map when the players leave a level
- Add disable effect on unavailable islands
- Synchronize multiplayers game on map

## Motivation and Context
We wanted to navigate the map and move forward in the game

## How has this been tested?
I tested the feature with single and multiplayer games

## Screenshots (if appropriate):
<img width="954" alt="Capture d’écran 2025-03-06 à 10 19 19" src="https://github.com/user-attachments/assets/9752d41d-21ee-4f7d-8b5c-c2101c20e28f" />

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.